### PR TITLE
Add Mechanism Game Over & Exception Handling Before Play The Game

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OBJECT := build/objects
 BIN := build/bin
 
 all: build main.o snake.o characters.o control.o score.o
-	$(CXX) $(CXX_FLAGS) $(OBJECT)/main.o $(OBJECT)/snake.o $(OBJECT)/characters.o $(OBJECT)/control.o $(OBJECT)/score.o -l$(LDLIBS) -o $(BIN)/snake
+	$(CXX) $(CXX_FLAGS) $(OBJECT)/main.o $(OBJECT)/snake.o $(OBJECT)/characters.o $(OBJECT)/control.o $(OBJECT)/score.o -L include/ncurses -l$(LDLIBS) -o $(BIN)/snake
 
 build:
 	if [ ! -d build/objects ] && [ ! -d build/bin ]; then \
@@ -14,19 +14,19 @@ build:
 	fi 
 
 main.o:
-	$(CXX) -c src/main.cpp $(CXX_FLAGS) -l$(LDLIBS) -o $(OBJECT)/main.o
+	$(CXX) -c src/main.cpp $(CXX_FLAGS) -o $(OBJECT)/main.o
 
 snake.o:
-	$(CXX) -c src/snake.cpp $(CXX_FLAGS) -l$(LDLIBS) -o $(OBJECT)/snake.o
+	$(CXX) -c src/snake.cpp $(CXX_FLAGS) -o $(OBJECT)/snake.o
 
 characters.o:
-	$(CXX) -c src/characters.cpp $(CXX_FLAGS) -l$(LDLIBS) -o $(OBJECT)/characters.o
+	$(CXX) -c src/characters.cpp $(CXX_FLAGS) -o $(OBJECT)/characters.o
 
 control.o:
-	$(CXX) -c src/control.cpp $(CXX_FLAGS) -l$(LDLIBS) -o $(OBJECT)/control.o
+	$(CXX) -c src/control.cpp $(CXX_FLAGS) -o $(OBJECT)/control.o
 
 score.o:
-	$(CXX) -c src/score.cpp $(CXX_FLAGS) -l$(LDLIBS) -o $(OBJECT)/score.o
+	$(CXX) -c src/score.cpp $(CXX_FLAGS) -o $(OBJECT)/score.o
 
 clean:
 	@echo "Clearing..."

--- a/include/snake.hpp
+++ b/include/snake.hpp
@@ -17,7 +17,6 @@ class Game {
 		int WindowHorizontalPosition;
 
 		// Member Property to Windows Name
-		const char* NameTitle;
 		const char* ScoreTitle;
 		
 		// Member Property to Create Windows
@@ -39,6 +38,10 @@ class Game {
 		// Size of Window Map
 		int xMax;
 		int yMax;
+
+		// Size Current Terminal
+		int rowTerminal;
+		int columnTerminal;
 
 		// Characters
 		char Food= '*'; // Food Character
@@ -64,8 +67,6 @@ class Game {
 		int xDirection = 1;
 		int yDirection = 0;
 
-
-
 	public:	
 		// Exit or Play Again
 		bool end = false;
@@ -85,6 +86,8 @@ class Game {
 		bool render();
 		bool GameOver();
 		void Play();
+		int getRowTerminalSize();
+		int getColumnTerminalSize();
 		~Game();
 };
 

--- a/include/snake.hpp
+++ b/include/snake.hpp
@@ -23,6 +23,7 @@ class Game {
 		// Member Property to Create Windows
 		WINDOW *Map;
 		WINDOW *Score;
+		WINDOW *GameOverPopUp;
 
 		// Member Property to Get Length Windows Name
 		size_t LengthName;
@@ -64,8 +65,12 @@ class Game {
 		int yDirection = 0;
 
 
+
 	public:	
-		Game(int, int, int, int, const char*, const char*);
+		// Exit or Play Again
+		bool end = false;
+		bool playAgain = false;
+		Game(int, int, int, int, const char*);
 		void UpdateScore(WINDOW*, int);
 		void startPosition();
 		void UpdatePosition();
@@ -77,7 +82,9 @@ class Game {
 		void mvDown();
 		void mvRight();
 		void mvLeft();
-		void render();
+		bool render();
+		bool GameOver();
+		void Play();
 		~Game();
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,8 +11,21 @@ int main() {
 	const char scoreTitle[] = "[ Score ]";
 	Game* Map = new Game(HEIGHT, WIDTH, WINDOWVERTICALPOSITION, WINDOWHORIZONTALPOSITION, scoreTitle);
 
-	Map->Play();
+	// Exception Handling
+	try {
+		if(Map->getRowTerminalSize() < 20 || Map->getColumnTerminalSize() < 50) {
+			throw "Small Terminal";
+		}
+
+		Map->Play();
+	}
+
+	catch(const char* error) {
+		Map->~Game();
+		std::cout << "Error : " << error << "\nThis game can't run on small terminal. Please resize your terminal to play the game\n";	
+	}
 
 	delete Map;
+
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,11 +8,10 @@
 
 int main() {
 	initscr();
-	const char gameTitle[] = "[ Snake CLI ]";
 	const char scoreTitle[] = "[ Score ]";
-	Game* Map = new Game(HEIGHT, WIDTH, WINDOWVERTICALPOSITION, WINDOWHORIZONTALPOSITION, gameTitle, scoreTitle);
-	
-	Map->render();
+	Game* Map = new Game(HEIGHT, WIDTH, WINDOWVERTICALPOSITION, WINDOWHORIZONTALPOSITION, scoreTitle);
+
+	Map->Play();
 
 	delete Map;
 	return 0;

--- a/src/snake.cpp
+++ b/src/snake.cpp
@@ -3,14 +3,13 @@
 #include <vector>
 #include "../include/snake.hpp"
 
-Game::Game(int height, int width, int windowVerticalPosition, int windowHorizontalPosition, const char* gameTitle, const char* scoreTitle) {
+Game::Game(int height, int width, int windowVerticalPosition, int windowHorizontalPosition, const char* scoreTitle) {
 	this->Height = height;
 	this->Width = width;
 
 	this->WindowVerticalPosition = windowVerticalPosition;
 	this->WindowHorizontalPosition = windowHorizontalPosition;
 
-	this->NameTitle = gameTitle;
 	this->ScoreTitle = scoreTitle;
 
 	// Map Window Inisialization
@@ -24,15 +23,46 @@ Game::Game(int height, int width, int windowVerticalPosition, int windowHorizont
 	// 0 = Window Position Vertical
 	// 0 = Window Position Horizontal
 	// 50 Position Horizontal after Width and + 5 for space
+	
+	// Game Over Pop Up Window
+	this->GameOverPopUp = newwin(10, 20, 4, 5);
 
-	this->LengthName = strlen(gameTitle);
 	this->LengthScore = strlen(scoreTitle);
 
-	this->PositionName = (Width - LengthName) / 2;
 	this->PositionScore = ((Width / 3) - LengthScore) / 2; // Ex : ((50 / 3) - 9) / 2)
 }
 
-void Game::render() {
+// Conditional When Game Over
+bool Game::GameOver() {
+	werase(Map);
+	mvwprintw(Map, 9, 20, "GAME OVER");
+	box(Map, 0, 0);	
+	wrefresh(Map);
+	refresh();
+	int choice = getch();
+	this->xHead = 5;
+	this->yHead = 4;
+	this->point = 0;
+	this->bodyLength = 4;
+	keypad(stdscr, TRUE);
+	
+	bool end = false;
+
+	switch(choice) {
+		case 'q':
+			end = true;
+			break;
+		case ' ':
+			end = false;
+			break;
+		default:
+			end = false;
+	}
+	return end;
+}
+
+// Render Game
+bool Game::render() {
 	keypad(stdscr, TRUE);
     box(Score, 0, 0);
     curs_set(FALSE); 
@@ -40,7 +70,7 @@ void Game::render() {
 	noecho();
 
 	startPosition();
-
+	
 	while(!gameOver) {
 
 		int choice = getch();
@@ -85,7 +115,6 @@ void Game::render() {
 
 		UpdatePosition();
 
-		mvwprintw(Map, 0, PositionName, NameTitle);
 		mvwprintw(Score, 0, PositionScore, ScoreTitle);
 
 		werase(Map);
@@ -101,8 +130,31 @@ void Game::render() {
 			generateFood(Map, yRandom, xRandom);
 		}
 
+		for(int i = 1; i < bodyLength; i++) {
+			if(xHead == xBody[i] && yHead == yBody[i]) {
+				gameOver = true;
+			}
+		}
+		
 		wrefresh(Map);
 		wrefresh(Score);
+	}
+	return gameOver;
+}
+
+// Looping Game
+void Game::Play() {
+	bool exit = false;
+	while(exit != true) {
+		if(render() == true) {
+			if(GameOver() == false) {
+				exit = false;
+			} else {
+				exit = true;
+			}
+		} else {
+			render();
+		}
 	}
 }
 

--- a/src/snake.cpp
+++ b/src/snake.cpp
@@ -27,9 +27,21 @@ Game::Game(int height, int width, int windowVerticalPosition, int windowHorizont
 	// Game Over Pop Up Window
 	this->GameOverPopUp = newwin(10, 20, 4, 5);
 
+	// Get Terminal Size
+	getmaxyx(stdscr, rowTerminal, columnTerminal);
+
+	// Title Score Window
 	this->LengthScore = strlen(scoreTitle);
 
 	this->PositionScore = ((Width / 3) - LengthScore) / 2; // Ex : ((50 / 3) - 9) / 2)
+}
+
+int Game::getRowTerminalSize() {
+	return rowTerminal; 		
+}
+
+int Game::getColumnTerminalSize() {
+	return columnTerminal; 		
 }
 
 // Conditional When Game Over

--- a/todo.txt
+++ b/todo.txt
@@ -3,7 +3,8 @@ To do :
 2. Print All at console (map, character, etc) when first run
 3. Showing Food Character in Map Window [done]
 4. Update Body Length [done]
-5. Snake died after hit it body
+5. Snake died after hit it body[done]
 6. Snake Auto Move 
 7. Fix Score Update [done]
 8. Fix food not spawn in  array body & head
+9. Add Menu Mechanism and Game Over Mechanism


### PR DESCRIPTION
I have added a mechanism game over, but not final mechanism and also added exception handling to check current size terminal.

### Mechanism Game Over

I will start with explain mechanism game over

Before Game Over

![image](https://github.com/baguskokow/Snake-CLI/assets/99445085/0659b56f-2d6a-447e-a104-914e20aef051)

Game Over

![image](https://github.com/baguskokow/Snake-CLI/assets/99445085/de4089ae-ba03-4307-b86e-7e3d680a9b51)

Play Again

![image](https://github.com/baguskokow/Snake-CLI/assets/99445085/3501666a-1b0c-42ab-9a85-12c5d8a5c111)

Score & length Snake character will be reset to default.

### Exception Handling
 
![image](https://github.com/baguskokow/Snake-CLI/assets/99445085/6438f76d-929b-4196-a7fa-c78454fd8886)

When user run the game, exception handling will get current row & column size of Terminal. And if row < 20 or column < 50, User can't play the game.

![image](https://github.com/baguskokow/Snake-CLI/assets/99445085/e1a8c043-f88b-420d-8a25-cbe9dbbbfbca)